### PR TITLE
adding support for passing environment variables to consul-template process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin/*
 .kitchen.local.yml
 
 coverage/
+.chef/

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'krone.adam@gmail.com'
 license          'Apache v2.0'
 description      'Installs/Configures consul-template'
 long_description 'Installs/Configures consul-template'
-version          '0.11.0'
+version          '0.11.9'
 
 recipe 'consul-template', 'Installs, configures, and starts the consul-template service.'
 recipe 'consul-template::install_binary', 'Installs consul-template from binary.'

--- a/templates/default/consul-template-init.erb
+++ b/templates/default/consul-template-init.erb
@@ -16,6 +16,7 @@ NAME="consul-template"
 PIDFILE="/var/run/$NAME.pid"
 LOGFILE="/var/log/$NAME.log"
 
+[ -f /etc/default/${NAME} ] && . /etc/default/${NAME}
 export GOMAXPROCS=${GOMAXPROCS}
 
 get_pid() {


### PR DESCRIPTION
This branch forks v0.11.0 version of the upstream cookbook and adds to it the ability to pass environment variables into consul-template process. The variables are passed through **/etc/default/consul-template** file.